### PR TITLE
feat: add CAMB AI text-to-speech for note summaries

### DIFF
--- a/components/pages/recording/RecordingDesktop.tsx
+++ b/components/pages/recording/RecordingDesktop.tsx
@@ -20,6 +20,7 @@ export default function RecordingDesktop({
     transcription,
     title,
     _creationTime,
+    summaryAudioUrl,
   } = note;
   const [originalIsOpen, setOriginalIsOpen] = useState<boolean>(true);
 
@@ -85,7 +86,15 @@ export default function RecordingDesktop({
       <div className="grid h-full w-full grid-cols-2 px-[30px] lg:px-[45px]">
         <div className="relative min-h-[70vh] w-full border-r px-5 py-3 text-justify text-xl font-[300] leading-[114.3%] tracking-[-0.6px] lg:text-2xl">
           {transcription ? (
-            <div className="">{originalIsOpen ? transcription : summary}</div>
+            <div>
+              <div className="">{originalIsOpen ? transcription : summary}</div>
+              {!originalIsOpen && summaryAudioUrl && (
+                <div className="mt-6 flex items-center gap-3">
+                  <p className="text-sm opacity-60">Listen to summary</p>
+                  <audio controls src={summaryAudioUrl} className="h-8" />
+                </div>
+              )}
+            </div>
           ) : (
             // Loading state for transcript
             <ul className="animate-pulse space-y-3">

--- a/components/pages/recording/RecordingMobile.tsx
+++ b/components/pages/recording/RecordingMobile.tsx
@@ -12,7 +12,7 @@ export default function RecordingMobile({
   note: Doc<'notes'>;
   actionItems: Doc<'actionItems'>[];
 }) {
-  const { summary, transcription, title, _creationTime } = note;
+  const { summary, transcription, title, _creationTime, summaryAudioUrl } = note;
   const [transcriptOpen, setTranscriptOpen] = useState<boolean>(true);
   const [summaryOpen, setSummaryOpen] = useState<boolean>(false);
   const [actionItemOpen, setActionItemOpen] = useState<boolean>(false);
@@ -78,6 +78,12 @@ export default function RecordingMobile({
         {summaryOpen && (
           <div className="relative mt-2 min-h-[70vh] w-full px-4 py-3 text-justify font-light">
             {summary}
+            {summaryAudioUrl && (
+              <div className="mt-4 flex items-center gap-3">
+                <p className="text-sm opacity-60">Listen to summary</p>
+                <audio controls src={summaryAudioUrl} className="h-8" />
+              </div>
+            )}
           </div>
         )}
         {actionItemOpen && (

--- a/convex/camb.ts
+++ b/convex/camb.ts
@@ -1,0 +1,69 @@
+("use node");
+
+import { internalAction, internalMutation } from "./_generated/server";
+import { v } from "convex/values";
+import { internal } from "./_generated/api";
+
+const CAMB_API_BASE = "https://client.camb.ai/apis";
+
+function getCambApiKey(): string {
+  const key = process.env.CAMB_API_KEY;
+  if (!key) {
+    throw new Error("CAMB_API_KEY environment variable is not set");
+  }
+  return key;
+}
+
+// Generate TTS audio of a note summary using CAMB AI
+export const generateSpeech = internalAction({
+  args: {
+    id: v.id("notes"),
+    text: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const apiKey = getCambApiKey();
+
+    const res = await fetch(`${CAMB_API_BASE}/tts-stream`, {
+      method: "POST",
+      headers: {
+        "x-api-key": apiKey,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        text: args.text,
+        voice_id: 147320,
+        language: "en-us",
+        speech_model: "mars-flash",
+        output_configuration: { format: "wav" },
+      }),
+    });
+
+    if (!res.ok) {
+      throw new Error(`CAMB TTS failed: ${await res.text()}`);
+    }
+
+    const audioBuffer = await res.arrayBuffer();
+    const blob = new Blob([audioBuffer], { type: "audio/wav" });
+
+    const storageId = await ctx.storage.store(blob);
+
+    await ctx.runMutation(internal.camb.saveSummaryAudio, {
+      id: args.id,
+      summaryAudioFileId: storageId,
+    });
+  },
+});
+
+export const saveSummaryAudio = internalMutation({
+  args: {
+    id: v.id("notes"),
+    summaryAudioFileId: v.id("_storage"),
+  },
+  handler: async (ctx, args) => {
+    const url = await ctx.storage.getUrl(args.summaryAudioFileId);
+    await ctx.db.patch(args.id, {
+      summaryAudioFileId: args.summaryAudioFileId,
+      summaryAudioUrl: url ?? undefined,
+    });
+  },
+});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -10,6 +10,8 @@ export default defineSchema({
     transcription: v.optional(v.string()),
     summary: v.optional(v.string()),
     embedding: v.optional(v.array(v.float64())),
+    summaryAudioFileId: v.optional(v.id('_storage')),
+    summaryAudioUrl: v.optional(v.string()),
     generatingTranscript: v.boolean(),
     generatingTitle: v.boolean(),
     generatingActionItems: v.boolean(),

--- a/convex/together.ts
+++ b/convex/together.ts
@@ -128,6 +128,14 @@ export const saveSummary = internalMutation({
     await ctx.db.patch(id, {
       generatingActionItems: false,
     });
+
+    // Generate TTS audio of the summary using CAMB AI
+    if (summary && summary !== 'Summary failed to generate') {
+      await ctx.scheduler.runAfter(0, internal.camb.generateSpeech, {
+        id,
+        text: summary,
+      });
+    }
   },
 });
 


### PR DESCRIPTION
## Summary

- Adds CAMB AI text-to-speech so users can listen to their note summaries as audio
- After a summary is generated, CAMB AI's streaming TTS creates a spoken audio version
- A "Listen to summary" audio player appears in the Summary view (desktop and mobile)
- Uses CAMB AI's MARS speech models for low-latency, high-quality speech synthesis

## About CAMB AI

[CAMB AI](https://camb.ai) is a voice AI and localization platform trusted by brands like the Premier League, the NBA, NASCAR, and the Australian Open. We'd love for CAMB AI to power the audio experience in notesGPT.

## Note on testing

During testing, we found that the `@instructor-ai/instructor` library's `JSON_SCHEMA` mode no longer works with Together.ai's current serverless models. We had to switch to using the Together SDK directly with `meta-llama/Llama-3.3-70B-Instruct-Turbo` to get summaries working, which then allowed the CAMB TTS feature to trigger. This is not included in this PR but worth noting.

## Usage

1. Set `CAMB_API_KEY` in Convex environment variables (get a key from https://studio.camb.ai)
2. Record a voice note as usual
3. After the summary generates, toggle to "Summary" view
4. Click play on the "Listen to summary" audio player

## Files changed

- `convex/camb.ts` - New file: CAMB TTS generation action and audio storage
- `convex/schema.ts` - Added summaryAudioFileId and summaryAudioUrl fields to notes table
- `convex/together.ts` - Schedules CAMB TTS generation after summary is saved
- `components/pages/recording/RecordingDesktop.tsx` - Audio player in summary view
- `components/pages/recording/RecordingMobile.tsx` - Audio player in summary view (mobile)